### PR TITLE
Infections: removed "po dnevih relativno", reordered display types

### DIFF
--- a/src/visualizations/InfectionsChart.fs
+++ b/src/visualizations/InfectionsChart.fs
@@ -50,9 +50,9 @@ type DisplayType = {
 }
 
 let availableDisplayTypes: DisplayType array = [|
+    { Label = "Po dnevih"; IsRelative = true;  Stacking = Normal; ShowLegend = true }
     { Label = "Skupaj"; IsRelative = false; Stacking = Normal; ShowLegend = true }
     { Label = "Relativno"; IsRelative = false;  Stacking = Percent; ShowLegend = false }
-    { Label = "Po dnevih"; IsRelative = true;  Stacking = Normal; ShowLegend = true }
     |]
 
 type State = {

--- a/src/visualizations/InfectionsChart.fs
+++ b/src/visualizations/InfectionsChart.fs
@@ -51,9 +51,9 @@ type DisplayType = {
 
 let availableDisplayTypes: DisplayType array = [|
     { Label = "Skupaj"; IsRelative = false; Stacking = Normal; ShowLegend = true }
-    { Label = "Skupaj relativno"; IsRelative = false;  Stacking = Percent; ShowLegend = false }
+    { Label = "Relativno"; IsRelative = false;  Stacking = Percent; ShowLegend = false }
     { Label = "Po dnevih"; IsRelative = true;  Stacking = Normal; ShowLegend = true }
-    { Label = "Po dnevih relativno"; IsRelative = true;  Stacking = Percent; ShowLegend = false } |]
+    |]
 
 type State = {
     DisplayType : DisplayType

--- a/src/visualizations/Utils.fs
+++ b/src/visualizations/Utils.fs
@@ -6,6 +6,9 @@ open Feliz
 
 open Types
 
+/// <summary>
+/// Converts Some 0 value to None.
+/// </summary>
 let zeroToNone value =
     match value with
     | Some 0 -> None


### PR DESCRIPTION
As [discussed on Slack](https://app.slack.com/client/TV6C5MHJN/C01056ZMG3S/thread/C01056ZMG3S-1587184591.200000), "po dnevih relativno" has been removed from Infections and reordered display types so "Po dnevih" is now the first one.

Also implemented: support for line charts in Infections, but in the end we decided not to use them for Infections. Some terminology in the Infections code has been renamed to avoid confusion and some code has been cleaned up.