### PR TITLE
Move broken polyfill.io references to cloudflare

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
   <meta name="theme-color" content="#ffd922">
   <meta name="msapplication-TileColor" content="#ffd922">
   <meta name="msapplication-config" content="<%= BASE_URL %>images/browserconfig.xml">
-  <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=Intl.NumberFormat.~locale.sl%2CIntl.NumberFormat.~locale.hr%2CIntl.NumberFormat.~locale.en%2CIntl.NumberFormat.~locale.it%2CIntl.NumberFormat.~locale.de%2CIntersectionObserver"></script>
+  <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=Intl.NumberFormat.~locale.sl%2CIntl.NumberFormat.~locale.hr%2CIntl.NumberFormat.~locale.en%2CIntl.NumberFormat.~locale.it%2CIntl.NumberFormat.~locale.de%2CIntersectionObserver" crossorigin="anonymous"></script>
 </head>
 
 <body>

--- a/index_caddy.html
+++ b/index_caddy.html
@@ -23,7 +23,7 @@
   <meta name="theme-color" content="#ffd922">
   <meta name="msapplication-TileColor" content="#ffd922">
   <meta name="msapplication-config" content="https://{{.Host}}/images/browserconfig.xml">
-  <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=Intl.NumberFormat.~locale.sl%2CIntl.NumberFormat.~locale.hr%2CIntl.NumberFormat.~locale.en%2CIntl.NumberFormat.~locale.it%2CIntl.NumberFormat.~locale.de%2CIntersectionObserver"></script>
+  <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=Intl.NumberFormat.~locale.sl%2CIntl.NumberFormat.~locale.hr%2CIntl.NumberFormat.~locale.en%2CIntl.NumberFormat.~locale.it%2CIntl.NumberFormat.~locale.de%2CIntersectionObserver" crossorigin="anonymous"></script>
 </head>
 
 <body>


### PR DESCRIPTION
After 
* #824

It got abused and broken with time:
* https://www.sonatype.com/blog/polyfill.io-supply-chain-attack-hits-100000-websites-all-you-need-to-know
* https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack
* polyfill.io: `Failed to load resource: net::ERR_NAME_NOT_RESOLVED` and
* new service is available https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet/
* moved to use https://cdnjs.cloudflare.com/polyfill/